### PR TITLE
Added disabled dragging init feature gridster.js

### DIFF
--- a/dist/jquery.gridster.js
+++ b/dist/jquery.gridster.js
@@ -732,7 +732,8 @@
         draggable: {
             distance: 4,
             items: ".gs_w:not(.static)"
-        }
+        },
+        disable_drag: false
     };
 
 
@@ -807,7 +808,9 @@
         this.get_widgets_from_DOM();
         this.set_dom_grid_height();
         this.$wrapper.addClass('ready');
-        this.draggable();
+        if (!this.options.disable_drag) {
+            this.draggable();
+        }
 
         $(window).bind(
             'resize', throttle($.proxy(this.recalculate_faux_grid, this), 200));


### PR DESCRIPTION
In initial options you can disble draggin by adding disable_drag: true on options list at initialising gridster
