### PR TITLE
Improved gridster destroy func

### DIFF
--- a/src/jquery.draggable.js
+++ b/src/jquery.draggable.js
@@ -332,7 +332,7 @@
         this.disable();
 
         this.$container.off('selectstart', this.proxied_on_select_start);
-        this.$container.off(pointer_events.start, this.proxied_drag_handler);
+        this.$container.off(pointer_events.start, this.options.items, this.proxied_drag_handler);
         this.$body.off(pointer_events.end, this.proxied_pointer_events_end);
         this.$body.off(pointer_events.move, this.on_pointer_events_move);
         $(window).unbind('resize', this.on_window_resize);


### PR DESCRIPTION
Fixed gridster destroy function to properly remove leftover gridster classes and data when the function is called with removeDOM=false. This should allow gridster to be re-initialized cleanly.
